### PR TITLE
Fix final modularity

### DIFF
--- a/ECG_simple_example.py
+++ b/ECG_simple_example.py
@@ -27,6 +27,7 @@ def community_ecg(self, weights=None, ens_size=16, min_weight=0.05):
         W = [W[i]+b[i] for i in range(len(W))]
     W = [min_weight + (1-min_weight)*W[i]/ens_size for i in range(len(W))]
     part = self.community_multilevel(weights=W)
+    part._modularity_params['weights'] = weights
     ## Force min_weight outside 2-core
     core = self.shell_index()
     ecore = [min(core[x.tuple[0]],core[x.tuple[1]]) for x in self.es]

--- a/Notebooks/ECG.ipynb
+++ b/Notebooks/ECG.ipynb
@@ -27,6 +27,7 @@
     "        W = [W[i]+b[i] for i in range(len(W))]\n",
     "    W = [min_weight + (1-min_weight)*W[i]/ens_size for i in range(len(W))]\n",
     "    part = self.community_multilevel(weights=W)\n",
+    "    part._modularity_params['weights'] = weights\n",
     "    ## Force min_weight outside 2-core\n",
     "    core = self.shell_index()\n",
     "    ecore = [min(core[x.tuple[0]],core[x.tuple[1]]) for x in self.es]\n",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ def community_ecg(self, weights=None, ens_size=16, min_weight=0.05):
     ecore = [min(core[x.tuple[0]],core[x.tuple[1]]) for x in self.es]
     w = [W[i] if ecore[i]>1 else min_weight for i in range(len(ecore))]
     part = self.community_multilevel(weights=w)
+    part._modularity_params['weights'] = weights
     part.W = w
     part.CSI = 1-2*np.sum([min(1-i,i) for i in w])/len(w)
     return part

--- a/ecg.py
+++ b/ecg.py
@@ -63,6 +63,7 @@ def community_ecg(self, weights=None, ens_size = 16, min_weight = 0.05):
     ecore = [min(core[x.tuple[0]],core[x.tuple[1]]) for x in self.es]
     w = [W[i] if ecore[i]>1 else min_weight for i in range(len(ecore))]
     part = self.community_multilevel(weights=w)
+    part._modularity_params['weights'] = weights
     part.W = w
     part.CSI = 1-2*np.sum([min(1-i,i) for i in w])/len(w)
     return part


### PR DESCRIPTION
Use the graph's initial weights instead of the internally computed ECG weights within the final partition. This gives the correct modularity for the final partition.

The partition returned by community_ecg uses the ECG derived edge weights when computing modularity, instead of the original edge weights. This causes it to have a different modularity than e.g. multilevel Louvain even when proposing the same partition.

```
z = ig.Graph.Famous("zachary")
np.random.seed(5)
ml = z.community_multilevel()
ecg = z.community_ecg()
ml.membership == ecg.membership
>>> True
ecg.modularity == ml.modularity
>>> False
ecg.modularity
>>> 0.6206167358159239
ml.modularity
>>> 0.4188034188034188
```

Setting the partition's edge weights to the original edge weights (in this case None) allows the modularities to agree.

```
ecg._modularity_params['weights'] = None
# igraph caches modularity so need to recalculate it
ecg.recalculate_modularity()
ecg.modularity == ml.modularity
>>> True
```